### PR TITLE
Sync HTML with an audio track, narrating the presentation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -232,6 +232,7 @@ function makeBrowserifyTask(name) {
 
 const playerBrowserifyTask = parallel(
     makeBrowserifyTask("player"),
+    makeBrowserifyTask("narrated"),
     makeBrowserifyTask("presenter")
 );
 
@@ -266,11 +267,13 @@ function makeTemplateTask(target, tpl) {
 
 const electronTemplatesTask = parallel(
     makeTemplateTask("electron", "player"),
+    makeTemplateTask("electron", "narrated"),
     makeTemplateTask("electron", "presenter")
 );
 
 const browserTemplatesTask = parallel(
     makeTemplateTask("browser", "player"),
+    makeTemplateTask("browser", "narrated"),
     makeTemplateTask("browser", "presenter")
 );
 

--- a/src/js/Storage.js
+++ b/src/js/Storage.js
@@ -265,8 +265,10 @@ export class Storage {
         const svgName           = this.backend.getName(this.svgFileDescriptor);
         const htmlFileName      = replaceFileExtWith(svgName, ".sozi.html");
         const presenterFileName = replaceFileExtWith(svgName, "-presenter.sozi.html");
+        const narratedFileName  = replaceFileExtWith(svgName, ".narrated.sozi.html");
         this.createHTMLFile(htmlFileName, location);
         this.createPresenterHTMLFile(presenterFileName, location, htmlFileName);
+        this.createNarratedHTMLFile(narratedFileName, location, htmlFileName);
     }
 
     /** Create the presentation HTML file if it does not exist.
@@ -299,10 +301,26 @@ export class Storage {
     async createPresenterHTMLFile(name, location, htmlFileName) {
         try {
             const fileDescriptor = await this.backend.find(name, location);
-            this.backend.save(fileDescriptor, this.exportPresenterHTML(htmlFileName));
+            await this.backend.save(fileDescriptor, this.exportPresenterHTML(htmlFileName));
         }
         catch (err) {
-            this.backend.create(name, location, "text/html", this.exportPresenterHTML(htmlFileName));
+            await this.backend.create(name, location, "text/html", this.exportPresenterHTML(htmlFileName));
+        }
+    }
+
+    /** Create the narrated HTML file if it does not exist.
+     *
+     * @param {string} name - The name of the HTML file to create.
+     * @param {any} location - The location of the file (backend-dependent).
+     * @param {string} htmlFileName - The name of the presentation HTML file.
+     */
+    async createNarratedHTMLFile(name, location, htmlFileName) {
+        try {
+            const fileDescriptor = await this.backend.find(name, location);
+            await this.backend.save(fileDescriptor, this.exportNarratedHTML(htmlFileName));
+        }
+        catch (err) {
+            await this.backend.create(name, location, "text/html", this.exportNarratedHTML(htmlFileName));
         }
     }
 
@@ -385,6 +403,20 @@ export class Storage {
      */
     exportPresenterHTML(htmlFileName) {
         return nunjucks.render("presenter.html", {
+            pres: this.presentation,
+            soziHtml: htmlFileName
+        });
+    }
+
+    /** Generate the content of the narrated HTML file.
+     *
+     * The result is derived from the `narrated.html` template.
+     *
+     * @param {string} htmlFileName - The name of the presentation HTML file to play.
+     * @returns {string} - An HTML document content, as text.
+     */
+    exportNarratedHTML(htmlFileName) {
+        return nunjucks.render("narrated.html", {
             pres: this.presentation,
             soziHtml: htmlFileName
         });

--- a/src/js/narrated.js
+++ b/src/js/narrated.js
@@ -1,0 +1,94 @@
+
+window.addEventListener("load", () => {
+    const narrative = document.getElementById("narrative")
+
+    const timeToSlide = (() => {
+        const timeToSlide = new Map()
+        let prevSlide = 0
+        for (const x of narrative.dataset.timeToSlide.split(",")) {
+            const [time, slide] = x.split(":")
+            prevSlide = parseInt((slide === undefined) ? prevSlide+1 : slide)
+            timeToSlide.set(parseInt(time), prevSlide - 1)
+        }
+        return timeToSlide
+    })()
+    const slideToTimeIntervals = (() => {
+        const slideToTimeIntervals = new Map()
+        const process = (start, end, slide) => {
+            let timeIntervals = slideToTimeIntervals.get(slide)
+            if (timeIntervals === undefined) {
+                timeIntervals = []
+                slideToTimeIntervals.set(slide, timeIntervals)
+            }
+            timeIntervals.push([start, end])
+        }
+        let start, slide
+        for (const [end, nextSlide] of timeToSlide) {
+            if (start === undefined) {
+                start = end
+                slide = nextSlide
+                continue
+            }
+            process(start, end, slide)
+            start = end
+            slide = nextSlide
+        }
+        if (start !== undefined) {
+            process(start, Number.POSITIVE_INFINITY, slide)
+        }
+        return slideToTimeIntervals
+    })()
+
+    let currentSlide = 0
+
+    const updateAudio = (newSlide) => {
+        currentSlide = newSlide
+        const timeIntervals = slideToTimeIntervals.get(newSlide)
+        if (timeIntervals === undefined) {
+            narrative.pause()
+            return
+        }
+        const t = narrative.currentTime
+        let nearestTime
+        for (const [start, end] of timeIntervals) {
+            if (start <= t && t < end) {
+                return
+            }
+            if (nearestTime === undefined || start <= t) {
+                nearestTime = start
+            }
+        }
+        narrative.currentTime = nearestTime
+    }
+    const updateSlide = (target) => {
+        const t = narrative.currentTime
+        let targetSlide = 0
+        for (const [time, slide] of timeToSlide) {
+            if (time <= t) {
+                targetSlide = slide
+            }
+        }
+        if (targetSlide !== currentSlide) {
+            currentSlide = targetSlide
+            target.postMessage({name:"moveToFrame", args: [currentSlide]},"*")
+        }
+    }
+    window.addEventListener("message", (e) => {
+        switch(e.data.name) {
+            case "loaded":
+                const target = e.source
+                target.postMessage({name:"notifyOnFrameChange"},"*")
+                const frame = document.querySelector("iframe")
+                setInterval(() => {
+                    frame.focus()
+                }, 1000)
+                narrative.ontimeupdate = () => {
+                    updateSlide(target)
+                }
+                break
+            case "frameChange":
+                updateAudio(e.data.index)
+                break
+        }
+    })
+}, false)

--- a/src/templates/narrated.html
+++ b/src/templates/narrated.html
@@ -1,0 +1,47 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% raw %}
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <title>{{ pres.title }}</title>
+        <style>
+            html, body {
+                width: 100%;
+                height: 100%;
+                margin: 0;
+            }
+            .presentation-container {
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+            }
+            iframe {
+                border: none;
+            }
+            audio {
+                position: fixed;
+                right: 0;
+                bottom: 0;
+                width: 25%;
+            }
+        </style>
+    </head>
+    <body>
+        <iframe class="presentation-container" src="{{ soziHtml }}">
+            The Sozi presentation should play here.
+        </iframe>
+        <audio id="narrative" controls data-time-to-slide="0:1,1:3,2:6">
+             <source src="narrative.flac" type="audio/flac" preload="auto">
+             Audio HTML5 tag is not supported!
+        </audio>
+{% endraw %}
+        <script>{{'{% raw %}'}}{{ js|safe }}{{'{% endraw %}'}}</script>
+    </body>
+</html>


### PR DESCRIPTION
This merge request creates an alternative presenter, namely **FILE.narrated.sozi.html** for the input **FILE.svg** presentation, which will play the presentation file and a **narrative.flac** audio file in sync. The common use case is to share a captured presentation without requiring to convert the presentation and audio track to a video format which has two benefits:
1. Presentation quality is preserved in the html+svg+js format,
2. Exported file size is kept minimal.

Currently, the audio file must be named **narrative.flac** and placed in side of the **FILE.narrated.sozi.html** file.
Also the **data-time-to-slide** attribute in the **FILE.narrated.sozi.html** file needs to be updated manually.
These items (_audio file name and time-to-slide_) should be moved to the editor later.
The format of the **data-time-to-slide** attribute is as follows:
- A string of comma-separated descriptors
- Each descriptor specifies the time instant (in seconds) which should trigger a slide transition
- If some slides should be skipped or the presentation is not progressing linearly, descriptor can specify the target slide number (counting from one, as shown at the top-left of the presentation itself); for this purpose the time and slide index must be separated by a colon

For example, `<audio id="narrative" controls data-time-to-slide="0,4,8,11:2,13:4">` means that
- when **narrative.flac** is playing from 0 to 4 seconds, the first frame must be shown,
- when it is playing from 4 to 8 seconds, the second frame must be shown,
- when it is playing from 8 to 11 seconds, the third frame must be shown,
- when it is playing from 11 to 13 seconds, presentation must return to the second frame,
- when **narrative.flac** reaches to the 13th second, presentation must transition to the fourth frame.

The browser audio controls are shown at the bottom-right of the screen. Seeking the audio to any time will automatically change the rendered frame. And changing the rendered frame (e.g., by URL or clicking on the frames list) will automatically seek the audio to the corresponding moment.