### PR TITLE
Use inkscape --actions option instead of multiple --verb options

### DIFF
--- a/extras/texts2paths/texts2paths.py
+++ b/extras/texts2paths/texts2paths.py
@@ -41,9 +41,11 @@ if __name__ == '__main__':
     input_file.close()
 
     # Use Inkscape to convert each text element to a path
-    command = ["inkscape", "--verb=FileVacuum"]
+    command = ["inkscape", "--batch-process"]
+    actions = ["FileVacuum"]
     for t in texts:
-        command += ["--verb=EditDeselect", "--select=" + t.get("id"), "--verb=ObjectToPath"]
-    command += ["--verb=FileSave", "--verb=FileQuit", output_file_name]
+        actions += ["EditDeselect", "select-by-id:" + t.get("id"), "ObjectToPath"]
+    actions += ["FileSave"]
+    command += ["--actions=" + ";".join(actions), output_file_name]
 
     subprocess.call(command)


### PR DESCRIPTION
Testing with **Inkscape 1.1**, the [texts2path.py](../blob/master/extras/texts2paths/texts2paths.py) no longer works. It is required to specify one of the **--with-gui**, **--batch-process**, or **--shell** options. The **--with-gui** option is most similar to the previous behavior, but leads to crash in some scenarios. Also, the **--verb** options are being replaced with the new **--actions** option which requires the **--batch-process** option (and quits the inkscape automatically after running asked **actions**).

This merge request replaces usage of **verb** options with the new **actions** syntax.