### PR TITLE
transforms always to the coordinate space of the document's viewport

### DIFF
--- a/src/js/model/CameraState.js
+++ b/src/js/model/CameraState.js
@@ -276,7 +276,7 @@ export class CameraState {
 
         // Compute the coordinates of the center of the given SVG element
         // after its current transformation
-        const matrix = layerGroup.getCTM().inverse().multiply(svgElement.getCTM());
+        const matrix = layerGroup.getScreenCTM().inverse().multiply(svgElement.getScreenCTM());
         bboxCenter = bboxCenter.matrixTransform(matrix);
 
         // Compute the scaling factor applied to the given SVG element


### PR DESCRIPTION
Hello.

This merge request should solve issues like https://github.com/sozi-projects/Sozi/issues/647.
In fact, if the `svgElement` (e.g. an `<image>`) is a descendant of an inner `<svg>` element, `svgElement.getCTM()` returns a transformation matrix with respect to the viewport of the latter, while `layerGroup.getCTM()` provides one against the outermost `<svg>`'s viewport, leading to a unexpected transformations.
By using `getScreenCTM()`, the returned matrix refers always to the document's viewport.