### PR TITLE
Indent and outdent list contents in page notes by Ctrl and > and < keys

### DIFF
--- a/src/js/view/Properties.js
+++ b/src/js/view/Properties.js
@@ -188,7 +188,9 @@ export class Properties extends VirtualDOMView {
             _("Ctrl+2: Medium heading"),
             _("Ctrl+3: Small heading"),
             _("Ctrl+L: List"),
-            _("Ctrl+N: Numbered list")
+            _("Ctrl+N: Numbered list"),
+            _("Ctrl+>: Indent list entry"),
+            _("Ctrl+<: Outdent list entry"),
         ].join("<br>");
 
         const timeoutMsDisabled = controller.getFrameProperty("timeoutEnable").every(value => !value);
@@ -645,6 +647,12 @@ export class Properties extends VirtualDOMView {
                             break;
                         case 78: // Ctrl+N
                             document.execCommand("insertOrderedList", false, null);
+                            break;
+                        case 188: // Ctrl+<
+                            document.execCommand("outdent", false, null);
+                            break;
+                        case 190: // Ctrl+>
+                            document.execCommand("indent", false, null);
                             break;
                         default:
                             return;


### PR DESCRIPTION
When editing the **Notes** of a frame, some shortkeys are supported, such as Ctrl and B/b for bold-face, L/l for unordered lists, and N/n for ordered lists.
This pull request adds two other shortkeys: Ctrl and >/. for indenting a list entry and </, for outdenting a list entry.